### PR TITLE
Adobe Photoshop未区分Beta版本，导致全部走Beta版本注入路径，区分后正常注入

### DIFF
--- a/config.json
+++ b/config.json
@@ -644,7 +644,7 @@
             "extraShell": "signLrc.sh"
         },
         {
-            "packageName": "com.adobe.Photoshop",
+            "packageName": "com.adobe.Photoshop (Beta)",
             "appBaseLocate": "/Applications/Adobe Photoshop (Beta)/Adobe Photoshop (Beta).app",
             "injectFile": "AdobeAGM.framework/Versions/A/AdobeAGM",
             "deepSignApp": true,


### PR DESCRIPTION
rt